### PR TITLE
add support for running tests using mvn. removed dup dep from pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# VSCode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Running the mock server
 ---
 The mock server used to respond to the API calls you're making in the exercises is started and stopped automatically using a JUnit @Rule.
 
+
+Running the tests using Maven
+---
+
+```bash
+mvn clean compile test
+```
+
 Slides
 ---
 The .pptx/.pdf/.odp file in the root folder contains all slides from the workshop. Again, feel free to use, share and adapt them to fit your own requirements.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <restassured.version>4.3.1</restassured.version>
-        <restassured.version>4.2.0</restassured.version>
         <junit.version>4.13.1</junit.version>
         <junit.dataprovider.version>2.6</junit.dataprovider.version>
         <jackson.databind.version>2.11.3</jackson.databind.version>

--- a/src/test/java/answers/RestAssuredAnswers1Test.java
+++ b/src/test/java/answers/RestAssuredAnswers1Test.java
@@ -9,7 +9,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.*;
 import org.junit.*;
 
-public class RestAssuredAnswers1 {
+public class RestAssuredAnswers1Test {
 
 	private static RequestSpecification requestSpec;
 

--- a/src/test/java/answers/RestAssuredAnswers2Test.java
+++ b/src/test/java/answers/RestAssuredAnswers2Test.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 import com.tngtech.java.junit.dataprovider.*;
 
 @RunWith(DataProviderRunner.class)
-public class RestAssuredAnswers2 {
+public class RestAssuredAnswers2Test {
 
 	private static RequestSpecification requestSpec;
 

--- a/src/test/java/answers/RestAssuredAnswers3Test.java
+++ b/src/test/java/answers/RestAssuredAnswers3Test.java
@@ -11,7 +11,7 @@ import io.restassured.specification.*;
 
 import org.junit.*;
 
-public class RestAssuredAnswers3 {
+public class RestAssuredAnswers3Test {
 
 	private static RequestSpecification requestSpec;
 

--- a/src/test/java/answers/RestAssuredAnswers4Test.java
+++ b/src/test/java/answers/RestAssuredAnswers4Test.java
@@ -1,15 +1,15 @@
-package exercises;
+package answers;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.*;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.*;
-
-public class RestAssuredExercises4 {
+public class RestAssuredAnswers4Test {
 
 	private static RequestSpecification requestSpec;
 
@@ -24,7 +24,7 @@ public class RestAssuredExercises4 {
 			setPort(9876).
 			build();
 	}
-
+		
 	/*******************************************************
 	 * Perform a GET request to /xml/de/24848 to get the
 	 * list of places associated with German zip code 24848
@@ -35,16 +35,19 @@ public class RestAssuredExercises4 {
 	 * Use "response.places.place[2].placeName" as the GPath
 	 * expression to extract the required value from the response
 	 ******************************************************/
-
+	
 	@Test
 	public void getDeZipCode24848_checkThirdPlaceInList_expectKropp() {
-
+		
 		given().
 			spec(requestSpec).
 		when().
-		then();
+			get("/xml/de/24848").
+		then().
+			assertThat().
+			body("response.places.place[2].placeName", equalTo("Kropp"));
 	}
-
+	
 	/*******************************************************
 	 * Perform a GET request to /xml/de/24848 to get the
 	 * list of places associated with German zip code 24848
@@ -63,7 +66,10 @@ public class RestAssuredExercises4 {
 		given().
 			spec(requestSpec).
 		when().
-		then();
+			get("/xml/de/24848").
+		then().
+			assertThat().
+			body("response.places.place[1].@latitude", equalTo("54.45"));
 	}
 
 	/*******************************************************
@@ -77,14 +83,17 @@ public class RestAssuredExercises4 {
 	 * Can you create the correct GPath expression yourself,
 	 * using the examples as shown in the slides?
 	 ******************************************************/
-
+	
 	@Test
 	public void getDeZipCode24848_checkNumberOfPlacesInSH_expect4() {
-
+		
 		given().
 			spec(requestSpec).
 		when().
-		then();
+			get("/xml/de/24848").
+		then().
+			assertThat().
+			body("response.places.place.findAll{it.stateAbbreviation=='SH'}", hasSize(4));
 	}
 
 
@@ -99,13 +108,16 @@ public class RestAssuredExercises4 {
 	 * Can you create the correct GPath expression yourself,
 	 * using the examples as shown in the slides?
 	 ******************************************************/
-
+	
 	@Test
 	public void getDeZipCode24848_checkNumberOfPlacesStartingWithKlein_expect2() {
-
+		
 		given().
 			spec(requestSpec).
 		when().
-		then();
+			get("/xml/de/24848").
+		then().
+			assertThat().
+			body("response.places.place.placeName.grep(~/Klein.*/)", hasSize(2));
 	}
 }

--- a/src/test/java/answers/RestAssuredAnswers5Test.java
+++ b/src/test/java/answers/RestAssuredAnswers5Test.java
@@ -1,4 +1,4 @@
-package exercises;
+package answers;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import dataentities.Car;
@@ -10,7 +10,7 @@ import org.junit.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
 
-public class RestAssuredExercises5 {
+public class RestAssuredAnswers5Test {
 
 	private static RequestSpecification requestSpec;
 
@@ -26,7 +26,7 @@ public class RestAssuredExercises5 {
 			setContentType(ContentType.JSON).
 			build();
 	}
-
+		
 	/*******************************************************
 	 * Create a new Car object that represents a 2012 Ford Focus
 	 * by passing these values to the POJO constructor
@@ -36,17 +36,21 @@ public class RestAssuredExercises5 {
 	 * Verify that the response HTTP status code is equal to 200
 	 * (note that this will only work if you use these exact values!)
 	 ******************************************************/
-
+	
 	@Test
 	public void postCarObject_checkResponseHttpStatusCode_expect200() {
 
-		// Create an instance of the Car object first using
-
+		Car myCar = new Car("Ford", "Focus", 2012);
 
 		given().
 			spec(requestSpec).
+		and().
+			body(myCar).
 		when().
-		then();
+			post("/car/postcar").
+		then().
+			assertThat().
+			statusCode(200);
 	}
 
 	/*******************************************************
@@ -64,13 +68,12 @@ public class RestAssuredExercises5 {
 	@Test
 	public void getCarObject_checkModelYear_expect2016() {
 
-		// Deserialize the response to a car object first
-		// Use Car myCar = given(). ...
+		Car myCar = given().
+			spec(requestSpec).
+			when().
+			get("/car/getcar/alfaromeogiulia").
+			as(Car.class);
 
-		given().
-			when();
-
-		// Then, write a JUnit assertion to verify the modelYear
-		// using Assert.assertEquals(<expected>, <actual>)
+		Assert.assertEquals(2016, myCar.getModelYear());
 	}
 }

--- a/src/test/java/answers/RestAssuredAnswers6Test.java
+++ b/src/test/java/answers/RestAssuredAnswers6Test.java
@@ -1,6 +1,7 @@
-package exercises;
+package answers;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import dataentities.Car;
 import dataentities.Photo;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -10,12 +11,14 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.request;
 
-public class RestAssuredExercises6 {
+public class RestAssuredAnswers6Test {
 
 	private static RequestSpecification requestSpec;
 
@@ -26,7 +29,9 @@ public class RestAssuredExercises6 {
 	public static void createRequestSpecification() {
 
 		requestSpec = new RequestSpecBuilder().
-			setBaseUri("https://jsonplaceholder.typicode.com/").
+			setBaseUri("http://localhost").
+			setPort(9876).
+			setContentType(ContentType.JSON).
 			build();
 	}
 
@@ -42,13 +47,20 @@ public class RestAssuredExercises6 {
 		 * Store the user id in a variable of type int
 		 ******************************************************/
 
-		int userId;
+		int userId = given().
+				spec(requestSpec).
+			when().
+				get("/users").
+			then().
+				extract().
+				path("find{it.username=='Karianne'}.id");
 
 		/*******************************************************
 		 * Use a JUnit assertEquals to verify that the userId
 		 * is equal to 4
 		 ******************************************************/
 
+		Assert.assertEquals(4, userId);
 
 		/*******************************************************
 		 * Perform a GET to /albums and extract all albums that
@@ -59,13 +71,20 @@ public class RestAssuredExercises6 {
 		 * Store these in a variable of type List<Integer>.
 		 ******************************************************/
 
-		List<Integer> albumIds;
+		List<Integer> albumIds = given().
+				spec(requestSpec).
+			when().
+				get("/albums").
+			then().
+				extract().
+				path(String.format("findAll{it.userId==%d}.id", userId));
 
 		/*******************************************************
 		 * Use a JUnit assertEquals to verify that the list has
 		 * exactly 10 items (hint: use the size() method)
 		 ******************************************************/
 
+		Assert.assertEquals(10, albumIds.size());
 
 		/*******************************************************
 		 * Perform a GET to /albums/XYZ/photos, where XYZ is the
@@ -80,7 +99,11 @@ public class RestAssuredExercises6 {
 		 * (the accepted answer should help you solve this one).
 		 ******************************************************/
 
-		List<Photo> photos;
+		List<Photo> photos = Arrays.asList(given().
+				spec(requestSpec).
+				pathParam("albumId", albumIds.get(4)).
+			when().
+				get("/albums/{albumId}/photos").as(Photo[].class));
 
 		/*******************************************************
 		 * Use a JUnit assertEquals to verify that the title of
@@ -90,5 +113,6 @@ public class RestAssuredExercises6 {
 		 * specific index from a List
 		 ******************************************************/
 
+		Assert.assertEquals("pariatur sunt eveniet", photos.get(31).getTitle());
 	}
 }

--- a/src/test/java/exercises/RestAssuredExamplesTest.java
+++ b/src/test/java/exercises/RestAssuredExamplesTest.java
@@ -15,7 +15,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 @RunWith(DataProviderRunner.class)
-public class RestAssuredExamples {
+public class RestAssuredExamplesTest {
 
     @Test
     public void usePreviouslyStoredAuthToken() {

--- a/src/test/java/exercises/RestAssuredExamplesXmlTest.java
+++ b/src/test/java/exercises/RestAssuredExamplesXmlTest.java
@@ -5,7 +5,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 @Ignore
-public class RestAssuredExamplesXml {
+public class RestAssuredExamplesXmlTest {
 
     @Test
     public void checkCountryForFirstCar() {

--- a/src/test/java/exercises/RestAssuredExercises1Test.java
+++ b/src/test/java/exercises/RestAssuredExercises1Test.java
@@ -10,7 +10,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
-public class RestAssuredExercises1 {
+public class RestAssuredExercises1Test {
 
 	private static RequestSpecification requestSpec;
 

--- a/src/test/java/exercises/RestAssuredExercises2Test.java
+++ b/src/test/java/exercises/RestAssuredExercises2Test.java
@@ -12,7 +12,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 @RunWith(DataProviderRunner.class)
-public class RestAssuredExercises2 {
+public class RestAssuredExercises2Test {
 
 	private static RequestSpecification requestSpec;
 

--- a/src/test/java/exercises/RestAssuredExercises3Test.java
+++ b/src/test/java/exercises/RestAssuredExercises3Test.java
@@ -10,7 +10,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
-public class RestAssuredExercises3 {
+public class RestAssuredExercises3Test {
 
 	private static RequestSpecification requestSpec;
 

--- a/src/test/java/exercises/RestAssuredExercises4Test.java
+++ b/src/test/java/exercises/RestAssuredExercises4Test.java
@@ -1,15 +1,15 @@
-package answers;
-
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static io.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
+package exercises;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.*;
 
-public class RestAssuredAnswers4 {
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+public class RestAssuredExercises4Test {
 
 	private static RequestSpecification requestSpec;
 
@@ -24,7 +24,7 @@ public class RestAssuredAnswers4 {
 			setPort(9876).
 			build();
 	}
-		
+
 	/*******************************************************
 	 * Perform a GET request to /xml/de/24848 to get the
 	 * list of places associated with German zip code 24848
@@ -35,19 +35,16 @@ public class RestAssuredAnswers4 {
 	 * Use "response.places.place[2].placeName" as the GPath
 	 * expression to extract the required value from the response
 	 ******************************************************/
-	
+
 	@Test
 	public void getDeZipCode24848_checkThirdPlaceInList_expectKropp() {
-		
+
 		given().
 			spec(requestSpec).
 		when().
-			get("/xml/de/24848").
-		then().
-			assertThat().
-			body("response.places.place[2].placeName", equalTo("Kropp"));
+		then();
 	}
-	
+
 	/*******************************************************
 	 * Perform a GET request to /xml/de/24848 to get the
 	 * list of places associated with German zip code 24848
@@ -66,10 +63,7 @@ public class RestAssuredAnswers4 {
 		given().
 			spec(requestSpec).
 		when().
-			get("/xml/de/24848").
-		then().
-			assertThat().
-			body("response.places.place[1].@latitude", equalTo("54.45"));
+		then();
 	}
 
 	/*******************************************************
@@ -83,17 +77,14 @@ public class RestAssuredAnswers4 {
 	 * Can you create the correct GPath expression yourself,
 	 * using the examples as shown in the slides?
 	 ******************************************************/
-	
+
 	@Test
 	public void getDeZipCode24848_checkNumberOfPlacesInSH_expect4() {
-		
+
 		given().
 			spec(requestSpec).
 		when().
-			get("/xml/de/24848").
-		then().
-			assertThat().
-			body("response.places.place.findAll{it.stateAbbreviation=='SH'}", hasSize(4));
+		then();
 	}
 
 
@@ -108,16 +99,13 @@ public class RestAssuredAnswers4 {
 	 * Can you create the correct GPath expression yourself,
 	 * using the examples as shown in the slides?
 	 ******************************************************/
-	
+
 	@Test
 	public void getDeZipCode24848_checkNumberOfPlacesStartingWithKlein_expect2() {
-		
+
 		given().
 			spec(requestSpec).
 		when().
-			get("/xml/de/24848").
-		then().
-			assertThat().
-			body("response.places.place.placeName.grep(~/Klein.*/)", hasSize(2));
+		then();
 	}
 }

--- a/src/test/java/exercises/RestAssuredExercises5Test.java
+++ b/src/test/java/exercises/RestAssuredExercises5Test.java
@@ -1,4 +1,4 @@
-package answers;
+package exercises;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import dataentities.Car;
@@ -10,7 +10,7 @@ import org.junit.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
 
-public class RestAssuredAnswers5 {
+public class RestAssuredExercises5Test {
 
 	private static RequestSpecification requestSpec;
 
@@ -26,7 +26,7 @@ public class RestAssuredAnswers5 {
 			setContentType(ContentType.JSON).
 			build();
 	}
-		
+
 	/*******************************************************
 	 * Create a new Car object that represents a 2012 Ford Focus
 	 * by passing these values to the POJO constructor
@@ -36,21 +36,17 @@ public class RestAssuredAnswers5 {
 	 * Verify that the response HTTP status code is equal to 200
 	 * (note that this will only work if you use these exact values!)
 	 ******************************************************/
-	
+
 	@Test
 	public void postCarObject_checkResponseHttpStatusCode_expect200() {
 
-		Car myCar = new Car("Ford", "Focus", 2012);
+		// Create an instance of the Car object first using
+
 
 		given().
 			spec(requestSpec).
-		and().
-			body(myCar).
 		when().
-			post("/car/postcar").
-		then().
-			assertThat().
-			statusCode(200);
+		then();
 	}
 
 	/*******************************************************
@@ -68,12 +64,13 @@ public class RestAssuredAnswers5 {
 	@Test
 	public void getCarObject_checkModelYear_expect2016() {
 
-		Car myCar = given().
-			spec(requestSpec).
-			when().
-			get("/car/getcar/alfaromeogiulia").
-			as(Car.class);
+		// Deserialize the response to a car object first
+		// Use Car myCar = given(). ...
 
-		Assert.assertEquals(2016, myCar.getModelYear());
+		given().
+			when();
+
+		// Then, write a JUnit assertion to verify the modelYear
+		// using Assert.assertEquals(<expected>, <actual>)
 	}
 }

--- a/src/test/java/exercises/RestAssuredExercises6Test.java
+++ b/src/test/java/exercises/RestAssuredExercises6Test.java
@@ -1,7 +1,6 @@
-package answers;
+package exercises;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import dataentities.Car;
 import dataentities.Photo;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -11,14 +10,12 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.request;
 
-public class RestAssuredAnswers6 {
+public class RestAssuredExercises6Test {
 
 	private static RequestSpecification requestSpec;
 
@@ -29,9 +26,7 @@ public class RestAssuredAnswers6 {
 	public static void createRequestSpecification() {
 
 		requestSpec = new RequestSpecBuilder().
-			setBaseUri("http://localhost").
-			setPort(9876).
-			setContentType(ContentType.JSON).
+			setBaseUri("https://jsonplaceholder.typicode.com/").
 			build();
 	}
 
@@ -47,20 +42,13 @@ public class RestAssuredAnswers6 {
 		 * Store the user id in a variable of type int
 		 ******************************************************/
 
-		int userId = given().
-				spec(requestSpec).
-			when().
-				get("/users").
-			then().
-				extract().
-				path("find{it.username=='Karianne'}.id");
+		int userId;
 
 		/*******************************************************
 		 * Use a JUnit assertEquals to verify that the userId
 		 * is equal to 4
 		 ******************************************************/
 
-		Assert.assertEquals(4, userId);
 
 		/*******************************************************
 		 * Perform a GET to /albums and extract all albums that
@@ -71,20 +59,13 @@ public class RestAssuredAnswers6 {
 		 * Store these in a variable of type List<Integer>.
 		 ******************************************************/
 
-		List<Integer> albumIds = given().
-				spec(requestSpec).
-			when().
-				get("/albums").
-			then().
-				extract().
-				path(String.format("findAll{it.userId==%d}.id", userId));
+		List<Integer> albumIds;
 
 		/*******************************************************
 		 * Use a JUnit assertEquals to verify that the list has
 		 * exactly 10 items (hint: use the size() method)
 		 ******************************************************/
 
-		Assert.assertEquals(10, albumIds.size());
 
 		/*******************************************************
 		 * Perform a GET to /albums/XYZ/photos, where XYZ is the
@@ -99,11 +80,7 @@ public class RestAssuredAnswers6 {
 		 * (the accepted answer should help you solve this one).
 		 ******************************************************/
 
-		List<Photo> photos = Arrays.asList(given().
-				spec(requestSpec).
-				pathParam("albumId", albumIds.get(4)).
-			when().
-				get("/albums/{albumId}/photos").as(Photo[].class));
+		List<Photo> photos;
 
 		/*******************************************************
 		 * Use a JUnit assertEquals to verify that the title of
@@ -113,6 +90,5 @@ public class RestAssuredAnswers6 {
 		 * specific index from a List
 		 ******************************************************/
 
-		Assert.assertEquals("pariatur sunt eveniet", photos.get(31).getTitle());
 	}
 }


### PR DESCRIPTION
This PR adds the ability to run tests using Maven right from the command-line.
I followed the convention where Test classes end up in "Test" so I've renamed them.
Also removed a duplicated/conflicting dependency on rest assured.